### PR TITLE
docs: add events category [VIZ-1392]

### DIFF
--- a/src/content/docs/plugin-api/camera.mdx
+++ b/src/content/docs/plugin-api/camera.mdx
@@ -595,7 +595,7 @@ import CameraSetView from "@code/plugin-api/camera/camera-set-view?raw";
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### move

--- a/src/content/docs/plugin-api/camera.mdx
+++ b/src/content/docs/plugin-api/camera.mdx
@@ -594,6 +594,10 @@ import CameraSetView from "@code/plugin-api/camera/camera-set-view?raw";
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### move
 
 This event is triggered whenever the camera's position or orientation changes within the `reearth` environment. This event allows users to listen for and respond to camera movements, providing the updated camera position and orientation.

--- a/src/content/docs/plugin-api/events.mdx
+++ b/src/content/docs/plugin-api/events.mdx
@@ -1,0 +1,93 @@
+---
+title: Events
+description: Common event handling in Plugin API
+sidebar:
+  order: 2
+---
+
+The Re:Earth Visualizer Plugin API provides a consistent pattern for handling events across different components. Events allow your plugin to respond to user interactions and system changes in real-time.
+
+## Common Event Methods
+
+All event-enabled components in the Re:Earth Visualizer share the same pattern for subscribing to and unsubscribing from events.
+
+### on
+
+The `on` method allows you to register an event listener that will be called when the specified event occurs.
+
+#### Syntax
+
+```typescript
+on<T extends keyof EventType>(
+  type: T,
+  callback: (...args: EventType[T]) => void,
+  options?: { once?: boolean }
+): void
+```
+
+#### Parameters
+
+- **type**: The event type to listen for
+- **callback**: Function to execute when the event occurs
+- **options** (optional): Configuration options
+  - **once**: When set to `true`, the listener will be automatically removed after being invoked once
+
+#### Example
+
+```javascript
+// Basic event listener
+reearth.popup.on("close", () => {
+  console.log("Popup was closed");
+});
+
+// Event listener that only triggers once
+reearth.layers.on(
+  "select",
+  (layer) => {
+    console.log("Layer selected (this will only trigger once):", layer.id);
+  },
+  { once: true }
+);
+```
+
+### off
+
+The `off` method allows you to remove a previously registered event listener.
+
+:::caution
+The `off` method is currently not functional in the current version. This
+feature will be implemented in a future release.
+:::
+
+#### Syntax
+
+```typescript
+off<T extends keyof EventType>(
+  type: T,
+  callback: (...args: EventType[T]) => void
+): void
+```
+
+#### Parameters
+
+- **type**: The event type to unregister
+- **callback**: The function that was previously registered with `on`
+
+#### Example
+
+```javascript
+// Define the callback function
+const handleClose = () => {
+  console.log("Popup was closed");
+};
+
+// Register the event listener
+reearth.popup.on("close", handleClose);
+
+// Later, when you want to stop listening
+reearth.popup.off("close", handleClose);
+```
+
+## Event Types
+
+Each component in the Re:Earth Visualizer has its own set of event types. Refer to the individual component documentation for specific event details.

--- a/src/content/docs/plugin-api/extension.mdx
+++ b/src/content/docs/plugin-api/extension.mdx
@@ -149,7 +149,7 @@ import PostExtensionCode from "@code/plugin-api/extension/post-extension?raw";
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### message

--- a/src/content/docs/plugin-api/extension.mdx
+++ b/src/content/docs/plugin-api/extension.mdx
@@ -148,6 +148,10 @@ import PostExtensionCode from "@code/plugin-api/extension/post-extension?raw";
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### message
 
 The message event triggers whenever a generic message is sent to the extension. This event is used to listen for messages from **current extension's UI (or modal, or popup)**.

--- a/src/content/docs/plugin-api/layers.mdx
+++ b/src/content/docs/plugin-api/layers.mdx
@@ -599,6 +599,10 @@ import selectFeaturesLayerCode from "@code/plugin-api/layers/selectfeatures-laye
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### select
 
 This event is triggered when a layer is selected within the `reearth` scene. It provides a way to listen for layer selection events and respond to them with custom actions or behaviors.

--- a/src/content/docs/plugin-api/layers.mdx
+++ b/src/content/docs/plugin-api/layers.mdx
@@ -600,7 +600,7 @@ import selectFeaturesLayerCode from "@code/plugin-api/layers/selectfeatures-laye
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### select

--- a/src/content/docs/plugin-api/modal.mdx
+++ b/src/content/docs/plugin-api/modal.mdx
@@ -164,7 +164,7 @@ reearth.modal.close();
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### close

--- a/src/content/docs/plugin-api/modal.mdx
+++ b/src/content/docs/plugin-api/modal.mdx
@@ -163,6 +163,10 @@ reearth.modal.close();
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### close
 
 The close event is triggered when the modal in **`reearth`** is closed. This event allows you to perform actions in response to the modal’s closure, such as cleaning up resources, saving data, or updating the UI. You can configure the listener to execute once or multiple times, based on the provided options.

--- a/src/content/docs/plugin-api/popup.mdx
+++ b/src/content/docs/plugin-api/popup.mdx
@@ -181,6 +181,10 @@ reearth.popup.close();
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### close
 
 The close event is triggered when the popup in **`reearth`** is closed. This event allows you to execute specific actions, such as cleaning up resources, updating the UI, or notifying other components when the popup is no longer visible.

--- a/src/content/docs/plugin-api/popup.mdx
+++ b/src/content/docs/plugin-api/popup.mdx
@@ -182,7 +182,7 @@ reearth.popup.close();
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### close

--- a/src/content/docs/plugin-api/sketch.mdx
+++ b/src/content/docs/plugin-api/sketch.mdx
@@ -115,7 +115,7 @@ None `(void)`. The method performs its operation without returning a value.
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### create

--- a/src/content/docs/plugin-api/sketch.mdx
+++ b/src/content/docs/plugin-api/sketch.mdx
@@ -24,7 +24,7 @@ reearth.sketch.tool: SketchType;
 
 #### Return Value
 
-**Type** `SketchType = 
+**Type** `SketchType =
   | "marker"
   | "polyline"
   | "circle"
@@ -113,6 +113,10 @@ reearth.sketch.overrideOptions: (options: SketchOptions) => void;
 None `(void)`. The method performs its operation without returning a value.
 
 ## Events
+
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
 
 ### create
 

--- a/src/content/docs/plugin-api/timeline.mdx
+++ b/src/content/docs/plugin-api/timeline.mdx
@@ -370,6 +370,10 @@ import setRangeTypeCode from "@code/plugin-api/timeline/set-range-type?raw";
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### tick
 
 The tick event fires every time the timeline's current time updates. This is typically triggered as the timeline progresses or is manually adjusted.

--- a/src/content/docs/plugin-api/timeline.mdx
+++ b/src/content/docs/plugin-api/timeline.mdx
@@ -371,7 +371,7 @@ import setRangeTypeCode from "@code/plugin-api/timeline/set-range-type?raw";
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### tick

--- a/src/content/docs/plugin-api/ui.mdx
+++ b/src/content/docs/plugin-api/ui.mdx
@@ -167,6 +167,10 @@ reearth.ui.close();
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### update
 
 The update event is triggered whenever the state or content of the UI changes. This can be useful for tracking changes to the UI state or refreshing content based on the latest data.

--- a/src/content/docs/plugin-api/ui.mdx
+++ b/src/content/docs/plugin-api/ui.mdx
@@ -168,7 +168,7 @@ reearth.ui.close();
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### update

--- a/src/content/docs/plugin-api/viewer.mdx
+++ b/src/content/docs/plugin-api/viewer.mdx
@@ -503,6 +503,10 @@ A boolean value that indicates whether the position is visible on the globe.
 
 ## Events
 
+:::note
+For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+:::
+
 ### resize
 
 `resize` event will be triggered when the viewer is resized.

--- a/src/content/docs/plugin-api/viewer.mdx
+++ b/src/content/docs/plugin-api/viewer.mdx
@@ -504,7 +504,7 @@ A boolean value that indicates whether the position is visible on the globe.
 ## Events
 
 :::note
-For more information about event common methods (`on`, `off`), please see the [Events](/plugin-api/events) page.
+For more information about common event methods (`on`, `off`), please refer to the [Events](/plugin-api/events) page.
 :::
 
 ### resize


### PR DESCRIPTION
- Added a general page Events under Plugin API reference
- Introduced the idea of methods on (including the option {once: true}) and off.
- Added a ref link to Events page on each event section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Introduced a new events guide detailing how to manage events using common methods.
  - Enhanced various API documentation sections with notes and links directing users to further information on event handling, specifically regarding the `on` and `off` methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->